### PR TITLE
Fix extension manifest persistent background

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,7 +5,7 @@
   "manifest_version": 2,
   "background": {
     "scripts": ["background.js"],
-    "persistent": false
+    "persistent": true
   },
   "page_action": {
     "default_title": "Download Slide Deck"


### PR DESCRIPTION
## Summary
- allow webRequest API by setting the background page to persistent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b4af2170833187a64365005f25fc